### PR TITLE
Jira refactoring

### DIFF
--- a/modules/core/.classpath
+++ b/modules/core/.classpath
@@ -11,5 +11,17 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" output="target/classes" path="dev/timeslottracker/resources/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="dev/timeslottracker/test-resources/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/modules/core/.classpath
+++ b/modules/core/.classpath
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/modules/core/.project
+++ b/modules/core/.project
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>timeslottracker-core</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<linkedResources>
+		<link>
+			<name>java</name>
+			<type>2</type>
+			<locationURI>TIMESLOTTRACKER/resources/java</locationURI>
+		</link>
+	</linkedResources>
+	<variableList>
+		<variable>
+			<name>TIMESLOTTRACKER</name>
+			<value>file:/C:/dev/timeslottracker</value>
+		</variable>
+	</variableList>
+</projectDescription>

--- a/modules/core/.settings/org.eclipse.jdt.core.prefs
+++ b/modules/core/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/modules/core/.settings/org.eclipse.m2e.core.prefs
+++ b/modules/core/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -5,6 +5,13 @@
     <version>1.3.23-SNAPSHOT</version>
     <name>TimeSlotTracker core version</name>
 
+    <properties>
+<!--        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding> -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>1.8</java.version>
+    </properties>
+
     <dependencies>
         <!-- csv/ical -->
         <dependency>
@@ -199,11 +206,10 @@
           </execution>
         </executions>
       </plugin>
-			<!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
+                <version>3.2.0</version>
                 <configuration>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
@@ -265,7 +271,6 @@
                     </execution>
                 </executions>
             </plugin>
-			-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -57,6 +57,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+        	<groupId>com.google.code.gson</groupId>
+        	<artifactId>gson</artifactId>
+        	<version>2.8.6</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -160,6 +165,41 @@
                     </dependency>
                 </dependencies>
             </plugin>
+      <plugin>
+        <!-- https://maven.apache.org/shared/maven-archiver/examples/classpath.html -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addClasspath>true</addClasspath>
+			  <classpathPrefix>deps/</classpathPrefix>
+			  <mainClass>net.sf.timeslottracker.Starter</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+	    <!-- https://maven.apache.org/plugins/maven-dependency-plugin/usage.html -->
+		<!-- https://maven.apache.org/plugins/maven-dependency-plugin/examples/copying-project-dependencies.html -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.1</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <!-- configure the plugin here -->
+			  <outputDirectory>${project.build.directory}/deps</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+			<!--
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -225,6 +265,7 @@
                     </execution>
                 </executions>
             </plugin>
+			-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/modules/full/pom.xml
+++ b/modules/full/pom.xml
@@ -5,6 +5,13 @@
     <version>1.3.23-SNAPSHOT</version>
     <name>TimeSlotTracker full version</name>
 
+  <properties>
+<!--    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding> -->
+	<maven.compiler.source>1.8</maven.compiler.source>
+	<maven.compiler.target>1.8</maven.compiler.target>
+	<java.version>1.8</java.version>
+  </properties>
+
     <dependencies>
         <dependency>
             <groupId>net.sf</groupId>

--- a/modules/full/pom.xml
+++ b/modules/full/pom.xml
@@ -131,7 +131,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
+                <version>3.2.0</version>
                 <configuration>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/resources/java/net/sf/timeslottracker/data/common/AttributeTypeManagerImpl.java
+++ b/resources/java/net/sf/timeslottracker/data/common/AttributeTypeManagerImpl.java
@@ -6,12 +6,13 @@ import java.util.HashMap;
 
 import net.sf.timeslottracker.data.AttributeType;
 import net.sf.timeslottracker.integrations.issuetracker.IssueKeyAttributeType;
+import net.sf.timeslottracker.integrations.issuetracker.IssueWorklogIdType;
 import net.sf.timeslottracker.integrations.issuetracker.IssueWorklogStatusType;
 import net.sf.timeslottracker.monitoring.ScreenshotAttributeType;
 
 /**
  * Attribute Type Manager implementation
- * 
+ *
  * @author User: zgibek Date: 2009-07-14 Time: 07:11:53 $Id: not-commited-yet
  *         zgibek Exp $
  */
@@ -32,12 +33,13 @@ public class AttributeTypeManagerImpl implements AttributeTypeManager {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see
    * net.sf.timeslottracker.data.common.AttributeTypeManager#get(java.lang.String
    * )
    */
-  public AttributeType get(String name) {
+  @Override
+public AttributeType get(String name) {
     if (name == null) {
       throw new NullPointerException("AttributeType's name can't be null");
     }
@@ -47,7 +49,7 @@ public class AttributeTypeManagerImpl implements AttributeTypeManager {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see net.sf.timeslottracker.data.common.AttributeTypeManager#list()
    */
   @Override
@@ -57,12 +59,13 @@ public class AttributeTypeManagerImpl implements AttributeTypeManager {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see
    * net.sf.timeslottracker.data.common.AttributeTypeManager#register(net.sf
    * .timeslottracker.data.AttributeType)
    */
-  public void register(AttributeType attributeType) {
+  @Override
+public void register(AttributeType attributeType) {
     String key = attributeType.getName();
     if (attributeTypes.containsKey(key)) {
       return;
@@ -73,7 +76,7 @@ public class AttributeTypeManagerImpl implements AttributeTypeManager {
 
   /*
    * (non-Javadoc)
-   * 
+   *
    * @see
    * net.sf.timeslottracker.data.common.AttributeTypeManager#update(java.util
    * .Collection)
@@ -92,6 +95,7 @@ public class AttributeTypeManagerImpl implements AttributeTypeManager {
     register(ScreenshotAttributeType.getInstance());
     register(IssueKeyAttributeType.getInstance());
     register(IssueWorklogStatusType.getInstance());
+    register(IssueWorklogIdType.getInstance());
   }
 
 }

--- a/resources/java/net/sf/timeslottracker/data/xml/XmlTimeSlot.java
+++ b/resources/java/net/sf/timeslottracker/data/xml/XmlTimeSlot.java
@@ -44,7 +44,7 @@ public class XmlTimeSlot implements TimeSlot {
    */
   XmlTimeSlot(Locale locale, Integer timeslotId, Date start, Date stop,
       String description) {
-    this.dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm", locale);
+    this.dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSZ", locale);
     this.id = timeslotId;
 
     setStartDate(start);
@@ -129,18 +129,26 @@ public class XmlTimeSlot implements TimeSlot {
     if (start == null) {
       value += "(?)";
     } else {
-      value += dateFormat.format(start);
+      value += format(start);
     }
     value += " - ";
     if (stop == null) {
       value += "(?)";
     } else {
-      value += dateFormat.format(stop);
+      value += format(stop);
     }
     if (description != null) {
       value += ": " + description;
     }
     return value;
+  }
+  
+  private String format(final Date date)
+  {
+	  synchronized(dateFormat)
+	  {
+		  return dateFormat.format(date);
+	  }
   }
 
   public boolean canBeStarted() {

--- a/resources/java/net/sf/timeslottracker/gui/TimeSlotEditDialog.java
+++ b/resources/java/net/sf/timeslottracker/gui/TimeSlotEditDialog.java
@@ -37,7 +37,7 @@ import net.sf.timeslottracker.utils.SwingUtils;
  * A simple timeslot edit dialog.
  * <p>
  * It is composed of several fields. One field for year, one for month, etc.
- * 
+ *
  * File version: $Revision: 1022 $, $Date: 2009-06-21 18:47:38 +0700 (Sun, 21 Jun
  * 2009) $ Last change: $Author: cnitsa $
  */
@@ -131,7 +131,8 @@ public class TimeSlotEditDialog extends JDialog implements EditingWindow {
 
     // listen if user double click on row to edit it
     table.addMouseListener(new MouseAdapter() {
-      public void mouseClicked(MouseEvent me) {
+      @Override
+	public void mouseClicked(MouseEvent me) {
         if (me.getClickCount() == 2) {
           edit();
         }
@@ -182,7 +183,7 @@ public class TimeSlotEditDialog extends JDialog implements EditingWindow {
 
   /**
    * Returns a new created or just saved timeslot
-   * 
+   *
    * @return new created or edited timeslot or null value if a user canceled
    *         dialog
    */
@@ -190,7 +191,8 @@ public class TimeSlotEditDialog extends JDialog implements EditingWindow {
     return timeslot;
   }
 
-  public void add() {
+  @Override
+public void add() {
     AttributeEditDialog dialog = new AttributeEditDialog(layoutManager, null,
         false, true, false);
     Attribute attribute = dialog.getAttribute();
@@ -203,7 +205,8 @@ public class TimeSlotEditDialog extends JDialog implements EditingWindow {
     }
   }
 
-  public void edit() {
+  @Override
+public void edit() {
     int rowNumber = table.getSelectedRow();
     if (rowNumber < 0) {
       return;
@@ -219,7 +222,8 @@ public class TimeSlotEditDialog extends JDialog implements EditingWindow {
     tableModel.fireTableRowsUpdated(rowNumber, rowNumber);
   }
 
-  public void remove() {
+  @Override
+public void remove() {
     int rowNumber = table.getSelectedRow();
     if (rowNumber < 0) {
       return;
@@ -233,11 +237,12 @@ public class TimeSlotEditDialog extends JDialog implements EditingWindow {
    * Action used when a user choose cancel/close button.
    * <p>
    * It simply reset task variable, so <code>getTimeslot</code> will return null
-   * 
+   *
    * @see #getTimeslot()
    */
   private class CancelAction implements ActionListener {
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       timeslot = null;
       close();
     }
@@ -255,11 +260,12 @@ public class TimeSlotEditDialog extends JDialog implements EditingWindow {
    * timeslot; <br>
    * If this is a new timeslot, new TimeSlot record will be created to be
    * returned with <code>getTimeslot</code> method.
-   * 
+   *
    * @see #getTimeslot()
    */
   private class SaveAction implements ActionListener {
-    public void actionPerformed(ActionEvent e) {
+    @Override
+	public void actionPerformed(ActionEvent e) {
       try {
         String description = inputComboBox.getDescription();
         // check if a description isn't empty
@@ -291,6 +297,8 @@ public class TimeSlotEditDialog extends JDialog implements EditingWindow {
             layoutManager.getTimeSlotTracker().setActiveTimeSlot(null);
             layoutManager.fireTimeSlotChanged(timeslot);
             layoutManager.getTimeSlotTracker().fireTaskChanged(timeslot.getTask());
+          } else {
+        	  layoutManager.fireTimeSlotChanged(timeslot);
           }
         }
         close();

--- a/resources/java/net/sf/timeslottracker/integrations/issuetracker/IssueWorklogIdType.java
+++ b/resources/java/net/sf/timeslottracker/integrations/issuetracker/IssueWorklogIdType.java
@@ -1,0 +1,29 @@
+package net.sf.timeslottracker.integrations.issuetracker;
+
+import net.sf.timeslottracker.data.AttributeType;
+import net.sf.timeslottracker.data.SimpleTextAttribute;
+
+public class IssueWorklogIdType extends AttributeType
+{
+	  private static IssueWorklogIdType INSTANCE;
+	  static {
+	    INSTANCE = new IssueWorklogIdType();
+	  }
+
+	  /** do not rename - will be persisted to xml */
+	  private static final String NAME = "ISSUE-WORKLOG-ID";
+
+	  private IssueWorklogIdType() {
+	    super(new SimpleTextAttribute());
+
+	    setName(NAME);
+	    setDescription("Key of worklog");
+	    setDefault("");
+	    setUsedInTasks(true);
+	    setBuiltin(true);
+	  }
+
+	  public static IssueWorklogIdType getInstance() {
+	    return INSTANCE;
+	  }
+	}

--- a/resources/java/net/sf/timeslottracker/integrations/issuetracker/jira/JiraClient.java
+++ b/resources/java/net/sf/timeslottracker/integrations/issuetracker/jira/JiraClient.java
@@ -1,0 +1,149 @@
+package net.sf.timeslottracker.integrations.issuetracker.jira;
+
+import static net.sf.timeslottracker.integrations.issuetracker.jira.JiraTracker.JIRA_VERSION_6;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.Date;
+import java.util.concurrent.ExecutorService;
+import java.util.logging.Logger;
+
+import javax.swing.JOptionPane;
+
+import net.sf.timeslottracker.core.Configuration;
+import net.sf.timeslottracker.core.TimeSlotTracker;
+import net.sf.timeslottracker.data.Attribute;
+import net.sf.timeslottracker.data.AttributeType;
+import net.sf.timeslottracker.data.Task;
+import net.sf.timeslottracker.data.TimeSlot;
+import net.sf.timeslottracker.integrations.issuetracker.Issue;
+import net.sf.timeslottracker.integrations.issuetracker.IssueHandler;
+import net.sf.timeslottracker.integrations.issuetracker.IssueKeyAttributeType;
+import net.sf.timeslottracker.integrations.issuetracker.IssueTrackerException;
+import net.sf.timeslottracker.integrations.issuetracker.IssueWorklogStatusType;
+import net.sf.timeslottracker.utils.StringUtils;
+
+abstract class JiraClient
+{
+	private static final Logger LOG = Logger.getLogger(JiraClient.class.getName());
+
+	private static final DateFormat TIMESTAMP = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+
+	private static final String JIRA_DEFAULT_VERSION = JIRA_VERSION_6;
+
+	protected final TimeSlotTracker timeSlotTracker;
+
+	protected final ExecutorService executorService;
+
+	/**
+	 * JIRA password per application runtime session
+	 */
+	protected String sessionPassword = StringUtils.EMPTY;
+
+	abstract void getFilterIssues(final String filterId, final IssueHandler handler)
+		      throws IssueTrackerException;
+
+	public abstract Issue getIssue(String key) throws IssueTrackerException;
+
+	abstract void upsertTimeslot(final TimeSlot timeSlot) throws IssueTrackerException;
+
+	protected String getBaseJiraUrl()
+	{
+		String url = this.timeSlotTracker.getConfiguration().getString(Configuration.JIRA_URL, "");
+
+		// truncate symbol / if present
+		if (url.endsWith("/"))
+		{
+			url = url.substring(0, url.length() - 1);
+		}
+
+		return url;
+	}
+
+	protected String getLogin()
+	{
+		return timeSlotTracker.getConfiguration().getString(Configuration.JIRA_LOGIN, "");
+	}
+
+	protected String getPassword()
+	{
+		final String password = timeSlotTracker.getConfiguration().getString(Configuration.JIRA_PASSWORD, null);
+
+		if (!StringUtils.isBlank(password))
+		{
+			return password;
+		}
+
+		synchronized(this)
+		{
+			if (StringUtils.isBlank(sessionPassword))
+			{
+				sessionPassword = JOptionPane.showInputDialog(timeSlotTracker.getRootFrame(),
+						timeSlotTracker.getString("issueTracker.credentialsInputDialog.password"));
+			}
+
+			return sessionPassword;
+		}
+	}
+
+	protected static String formatDate(final Date d)
+	{
+		synchronized (TIMESTAMP)
+		{
+			return TIMESTAMP.format(d);
+		}
+	}
+
+	protected Attribute getIssueWorkLogDuration(final TimeSlot timeSlot)
+	{
+		return getAttribute(timeSlot, IssueWorklogStatusType.getInstance());
+	}
+
+	protected Attribute getAttribute(final TimeSlot timeSlot, final AttributeType attrType)
+	{
+		for (Attribute attribute : timeSlot.getAttributes())
+		{
+			if (attribute.getAttributeType().equals(attrType))
+			{
+				return attribute;
+			}
+		}
+
+		return null;
+	}
+
+	protected Attribute getOrCreate(final TimeSlot timeslot, final AttributeType attrType)
+	{
+		final Collection<Attribute> attrs = timeslot.getAttributes();
+
+		synchronized (attrs)
+		{
+			if (attrs != null)
+				for (final Attribute attr : attrs)
+				{
+					if (attr.getAttributeType().equals(attrType))
+						return attr;
+				}
+
+			final Attribute attr = new Attribute(attrType);
+
+			attrs.add(attr);
+
+			return attr;
+		}
+	}
+
+	protected String getIssueKey(Task task)
+	{
+		for (Attribute attribute : task.getAttributes())
+		{
+			if (attribute.getAttributeType().equals(IssueKeyAttributeType.getInstance()))
+			{
+				return String.valueOf(attribute.get());
+			}
+		}
+
+		return null;
+	}
+}

--- a/resources/java/net/sf/timeslottracker/integrations/issuetracker/jira/JiraClientImpl.java
+++ b/resources/java/net/sf/timeslottracker/integrations/issuetracker/jira/JiraClientImpl.java
@@ -1,0 +1,294 @@
+package net.sf.timeslottracker.integrations.issuetracker.jira;
+
+import static net.sf.timeslottracker.integrations.issuetracker.jira.JiraClient.JIRA_DEFAULT_VERSION;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.text.MessageFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+
+import net.sf.timeslottracker.core.Configuration;
+import net.sf.timeslottracker.core.TimeSlotTracker;
+import net.sf.timeslottracker.data.Attribute;
+import net.sf.timeslottracker.data.TimeSlot;
+import net.sf.timeslottracker.integrations.issuetracker.Issue;
+import net.sf.timeslottracker.integrations.issuetracker.IssueHandler;
+import net.sf.timeslottracker.integrations.issuetracker.IssueTrackerException;
+import net.sf.timeslottracker.integrations.issuetracker.IssueWorklogStatusType;
+
+final class JiraClientImpl extends JiraClient
+{
+	private static final Logger LOG = Logger.getLogger(JiraClientV6.class.getName());
+
+	private final TimeSlotTracker timeSlotTracker;
+
+	private final ExecutorService executorService;
+
+	private final String version;
+
+	JiraClientImpl()
+	{
+	    this.version = timeSlotTracker.getConfiguration().get(Configuration.JIRA_VERSION, JIRA_DEFAULT_VERSION);
+	}
+
+	@Override
+	void getFilterIssues(final String filterId, final IssueHandler handler) throws IssueTrackerException
+	{
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public Issue getIssue(String key) throws IssueTrackerException
+	{
+		try
+		{
+			key = prepareKey(key);
+			if (key == null)
+			{
+				return null;
+			}
+
+			String urlString = MessageFormat.format(issueUrlTemplate, getBaseJiraUrl(), key, getAuthorizedParams());
+			URL url = new URL(urlString);
+			URLConnection connection = getUrlConnection(url);
+			try
+			{
+				BufferedReader br = new BufferedReader(
+						new InputStreamReader(connection.getInputStream()));
+				String line = br.readLine();
+				String id = null;
+				String summary = null;
+				while (line != null)
+				{
+					line = decodeString(line);
+					Matcher matcherId = patternIssueId.matcher(line);
+					if (id == null && matcherId.find())
+					{
+						id = matcherId.group(1);
+						continue;
+					}
+
+					Matcher matcherSummary = patternSummary.matcher(line);
+					if (summary == null && matcherSummary.find())
+					{
+						summary = matcherSummary.group(1);
+						continue;
+					}
+
+					if (id != null && summary != null)
+					{
+						return new JiraIssue(key, id, summary);
+					}
+
+					line = br.readLine();
+				}
+			}
+			finally
+			{
+				connection.getInputStream().close();
+			}
+			return null;
+		}
+		catch (FileNotFoundException e)
+		{
+			return null;
+		}
+		catch (IOException e)
+		{
+			throw new IssueTrackerException(e);
+		}
+	}
+
+	@Override
+	void upsertTimeslot(final TimeSlot timeSlot) throws IssueTrackerException
+	{
+		// getting issue key
+		final String key = getIssueKey(timeSlot.getTask());
+		if (key == null)
+		{
+			return;
+		}
+
+		LOG.info("Updating jira worklog for issue with key " + key + " ...");
+
+		// analyze the existing worklog status and duration
+		final long duration;
+		final Attribute statusAttribute = getIssueWorkLogDuration(timeSlot);
+		if (statusAttribute != null && !version.equals(JIRA_VERSION_6))
+		{
+			int lastDuration = Integer.parseInt(String.valueOf(statusAttribute.get()));
+			if (timeSlot.getTime() <= lastDuration)
+			{
+				LOG.info("Skipped updating jira worklog for issue with key " + key
+						+ ". Reason: current timeslot duration <= already saved in worklog");
+				return;
+			}
+
+			duration = timeSlot.getTime() - lastDuration;
+
+			LOG.info("Stop => timeSlot.getTime()=" + timeSlot.getTime() + " duration=" + duration + " lastDuration= "
+					+ lastDuration);
+		}
+		else
+		{
+			duration = timeSlot.getTime();
+
+			LOG.info("Stop => timeSlot.getTime()=" + timeSlot.getTime() + " duration=" + duration);
+		}
+
+		Runnable searchIssueTask = () ->
+		{
+			Issue issue = null;
+			try
+			{
+				issue = getIssue(key);
+			}
+			catch (IssueTrackerException e2)
+			{
+				LOG.info(e2.getMessage());
+			}
+			if (issue == null)
+			{
+				LOG.info("Nothing updated. Not found issue with key " + key);
+				return;
+			}
+
+			final String issueId = issue.getId();
+			Runnable updateWorklogTask = () ->
+			{
+				try
+				{
+					addWorklog(timeSlot, key, issueId, statusAttribute, duration);
+				}
+				catch (IOException e)
+				{
+					final String start = formatDate(timeSlot.getStartDate());
+
+					LOG.log(Level.WARNING, "Error occured while updating jira worklog for issue " + key + " (start="
+							+ start + " duration=" + duration + ")", e);
+				}
+			};
+			executorService.execute(updateWorklogTask);
+		};
+		executorService.execute(searchIssueTask);
+	}
+
+	private void addWorklog(
+			final TimeSlot timeSlot,
+			final String key,
+			final String issueId,
+			Attribute statusAttribute,
+			long duration
+	) throws IOException
+	{
+		final URL url = new URL(getBaseJiraUrl() + getAddWorklogPath(issueId));
+		final URLConnection connection = getUrlConnection(url);
+
+		if (connection instanceof HttpURLConnection)
+		{
+			HttpURLConnection httpConnection = (HttpURLConnection) connection;
+			httpConnection.setRequestMethod("POST");
+			httpConnection.setDoInput(true);
+			httpConnection.setDoOutput(true);
+			httpConnection.setUseCaches(false);
+			httpConnection.setRequestProperty("Content-Type", getContentType());
+
+			// sending data
+			try (final OutputStreamWriter writer = new OutputStreamWriter(httpConnection.getOutputStream()))
+			{
+				String jiraDuration = (duration / 1000 / 60) + "m";
+				LOG.finest(
+						"addWorkLog => jiraDuration=" + jiraDuration + " started=" + formatDate(timeSlot.getStartDate())
+								+ " comment=" + timeSlot.getDescription() + " toString=" + timeSlot.toString()
+				);
+
+				writer.append(getAuthorizedParams()).append(getPair("id", issueId))
+						.append(getPair("comment", URLEncoder.encode(timeSlot.getDescription(), "UTF-8")))
+						.append(getPair("worklogId", "")).append(getPair("timeLogged", jiraDuration)).append(
+								getPair("startDate",
+										URLEncoder.encode(new SimpleDateFormat("dd/MMM/yy KK:mm a")
+												.format(timeSlot.getStartDate()), "UTF-8")))
+						.append(getPair("adjustEstimate", "auto")).append(getPair("newEstimate", ""))
+						.append(getPair("commentLevel", ""));
+			}
+
+			try (final BufferedReader br = new BufferedReader(
+					new InputStreamReader(connection.getInputStream())))
+			{
+				final String line = br.readLine();
+
+				LOG.finest("jira result: " + line);
+			}
+
+			if (statusAttribute == null)
+			{
+				statusAttribute = new Attribute(IssueWorklogStatusType.getInstance());
+				final List<Attribute> list = new ArrayList<Attribute>(timeSlot.getAttributes());
+				list.add(statusAttribute);
+				timeSlot.setAttributes(list);
+			}
+
+			statusAttribute.set(timeSlot.getTime());
+
+			LOG.info("Updated jira worklog with key: " + key);
+		}
+	}
+
+	private URLConnection getUrlConnection(URL url) throws IOException
+	{
+		LOG.finest("Accessing : " + url);
+
+		final URLConnection connection = url.openConnection();
+
+		return connection;
+	}
+
+	private String getAddWorklogPath(String issueId)
+	{
+		final String path;
+
+		if (version.equals(JIRA_VERSION_3))
+		{
+			path = "/secure/LogWork.jspa";
+		}
+		else if (version.equals(JIRA_VERSION_310))
+		{
+			path = "/secure/CreateWorklog.jspa";
+		}
+		else
+		{
+			throw new IllegalStateException("Should never get here.");
+		}
+
+		return path;
+	}
+
+	private String getAuthorizedParams()
+	{
+		return "os_username=" + getLogin() + getPair("os_password", getPassword());
+	}
+
+	private String getPair(String name, String value)
+	{
+		return "&" + name + "=" + value;
+	}
+
+	private String getContentType()
+	{
+		return "application/x-www-form-urlencoded";
+	}
+}

--- a/resources/java/net/sf/timeslottracker/integrations/issuetracker/jira/JiraClientV6.java
+++ b/resources/java/net/sf/timeslottracker/integrations/issuetracker/jira/JiraClientV6.java
@@ -1,0 +1,227 @@
+package net.sf.timeslottracker.integrations.issuetracker.jira;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.codec.binary.Base64;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import net.sf.timeslottracker.data.Attribute;
+import net.sf.timeslottracker.data.TimeSlot;
+import net.sf.timeslottracker.integrations.issuetracker.Issue;
+import net.sf.timeslottracker.integrations.issuetracker.IssueHandler;
+import net.sf.timeslottracker.integrations.issuetracker.IssueTrackerException;
+import net.sf.timeslottracker.integrations.issuetracker.IssueWorklogIdType;
+import net.sf.timeslottracker.integrations.issuetracker.IssueWorklogStatusType;
+
+/**
+ * https://docs.atlassian.com/software/jira/docs/api/REST/7.1.2/
+ * @author jf.cloutier
+ *
+ */
+final class JiraClientV6 extends JiraClient
+{
+	private static final Logger LOG = Logger.getLogger(JiraClientV6.class.getName());
+
+	@Override
+	void getFilterIssues(final String filter, final IssueHandler handler) throws IssueTrackerException
+	{
+		final String jql;
+
+		if (filter.matches("^(?:-1|\\d+)$"))
+		{
+			final JsonObject resp = JsonParser.parseReader(new InputStreamReader(is, StandardCharsets.UTF_8)).getAsJsonObject();
+
+			jql = resp.get("jql").getAsString();
+		}
+		else
+		{
+			jql = filter;
+		}
+
+		final JsonArray jsonArr = new JsonArray();
+
+		jsonArr.add("id");
+		jsonArr.add("key");
+		jsonArr.add("summary");
+
+		final JsonObject jsonObj = new JsonObject();
+
+		jsonObj.addProperty("jql", jql);
+		jsonObj.addProperty("startAt", 0);
+		jsonObj.addProperty("maxResults", 100);
+		jsonObj.add("fields", jsonArr);
+
+		///
+
+		final JsonObject resp = JsonParser.parseReader(new InputStreamReader(is, StandardCharsets.UTF_8)).getAsJsonObject();
+		final JsonElement issues = resp.get("issues");
+
+		if (issues == null || !issues.isJsonArray())
+			return;
+
+		for (final JsonElement item : issues.getAsJsonArray())
+		{
+			final JsonObject issue = item.getAsJsonObject();
+
+			handler.handle(createIssue(issue));
+		}
+	}
+
+	@Override
+	void upsertTimeslot(final TimeSlot timeSlot) throws IssueTrackerException
+	{
+		final String key = getIssueKey(timeSlot.getTask());
+
+		if (key == null)
+		{
+			// This is not a Jira task.
+			return;
+		}
+
+		LOG.info("Updating jira worklog for issue with key " + key + " ...");
+
+		Runnable updateWorklogTask = () ->
+		{
+			try
+			{
+				addWorklog(timeSlot, key);
+			}
+			catch (IOException e)
+			{
+				final String start = formatDate(timeSlot.getStartDate());
+
+				LOG.log(Level.WARNING, "Error occured while updating jira worklog for issue " + key + " (start="
+						+ start + " duration=" + timeSlot.getTime() + ")", e);
+			}
+		};
+
+		executorService.execute(updateWorklogTask);
+	}
+
+	private void addWorklog(final TimeSlot timeSlot, final String key) throws IOException
+	{
+		final StringBuilder sb = new StringBuilder();
+
+		sb.append(getBaseJiraUrl()).append(getAddWorklogPath(key));
+
+		final Attribute worklogId = getAttribute(timeSlot, IssueWorklogIdType.getInstance());
+		String requestMethod = "POST";
+
+		if (worklogId != null)
+		{
+			sb.append('/').append(worklogId.get());
+			requestMethod = "PUT";
+		}
+
+		final URL url = new URL(sb.toString());
+		final HttpURLConnection conn = getUrlConnection(url);
+
+		conn.setRequestMethod(requestMethod);
+		conn.setDoInput(true);
+		conn.setDoOutput(true);
+		conn.setUseCaches(false);
+		conn.setRequestProperty("Content-Type", getContentType());
+
+		// sending data
+		try (final OutputStreamWriter writer = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8))
+		{
+			final long duration = timeSlot.getTime();
+			final JsonObject jsonObject = new JsonObject();
+
+			jsonObject.addProperty("timeSpentSeconds", duration / 1000L);
+			jsonObject.addProperty("started", formatDate(timeSlot.getStartDate()));
+			jsonObject.addProperty("comment", timeSlot.getDescription());
+
+			final String json = jsonObject.toString();
+
+			writer.append(json);
+		}
+
+		try (final Reader reader = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))
+		{
+			final JsonObject jsonObj = JsonParser.parseReader(reader).getAsJsonObject();
+			final String id = jsonObj.get("id").getAsString();
+
+			getOrCreate(timeSlot, IssueWorklogIdType.getInstance()).set(id);
+
+			LOG.finest("jira result: " + jsonObj.toString());
+		}
+
+		getOrCreate(timeSlot, IssueWorklogStatusType.getInstance()).set(timeSlot.getTime());
+
+		LOG.info("Updated jira worklog with key: " + key);
+	}
+
+	@Override
+	public Issue getIssue(final String key) throws IssueTrackerException
+	{
+		try
+		{
+			final URL url = new URL(getBaseJiraUrl() + "/rest/api/2/issue/" + key);
+			final HttpURLConnection conn = getUrlConnection(url);
+
+			conn.setUseCaches(false);
+			conn.setRequestProperty("Content-Type", getContentType());
+
+			final JsonObject issue;
+
+			try (final Reader reader = new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))
+			{
+				issue = JsonParser.parseReader(reader).getAsJsonObject();
+			}
+
+			LOG.finest("jira result: " + issue.toString());
+
+			return createIssue(issue);
+		}
+		catch (final Exception e)
+		{
+			throw new IssueTrackerException(e);
+		}
+	}
+
+	private Issue createIssue(final JsonObject issue)
+	{
+		// TODO what about isSubTask?
+
+		return new JiraIssue(
+				issue.get("key").getAsString(),
+				issue.get("id").getAsString(),
+				issue.get("summary").getAsString()
+		);
+	}
+
+	private HttpURLConnection getUrlConnection(URL url) throws IOException
+	{
+		LOG.finest("Accessing : " + url);
+
+		final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+		final String basicAuth = "Basic " + new String(new Base64().encode((getLogin() + ":" + getPassword()).getBytes()));
+
+		connection.setRequestProperty("Authorization", basicAuth);
+
+		return connection;
+	}
+
+	private String getAddWorklogPath(String issueId)
+	{
+		return "/rest/api/2/issue/" + issueId + "/worklog";
+	}
+
+	private String getContentType()
+	{
+		return "application/json";
+	}
+}

--- a/resources/java/net/sf/timeslottracker/integrations/issuetracker/jira/JiraTracker.java
+++ b/resources/java/net/sf/timeslottracker/integrations/issuetracker/jira/JiraTracker.java
@@ -6,20 +6,27 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.io.Reader;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.MessageFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -33,10 +40,16 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+
 import net.sf.timeslottracker.core.Action;
 import net.sf.timeslottracker.core.Configuration;
 import net.sf.timeslottracker.core.TimeSlotTracker;
 import net.sf.timeslottracker.data.Attribute;
+import net.sf.timeslottracker.data.AttributeType;
 import net.sf.timeslottracker.data.DataLoadedListener;
 import net.sf.timeslottracker.data.Task;
 import net.sf.timeslottracker.data.TimeSlot;
@@ -46,12 +59,14 @@ import net.sf.timeslottracker.integrations.issuetracker.IssueHandler;
 import net.sf.timeslottracker.integrations.issuetracker.IssueKeyAttributeType;
 import net.sf.timeslottracker.integrations.issuetracker.IssueTracker;
 import net.sf.timeslottracker.integrations.issuetracker.IssueTrackerException;
+import net.sf.timeslottracker.integrations.issuetracker.IssueWorklogIdType;
 import net.sf.timeslottracker.integrations.issuetracker.IssueWorklogStatusType;
 import net.sf.timeslottracker.utils.StringUtils;
 
 /**
  * Implementation of Issue Tracker for Jira
- *
+ * https://docs.atlassian.com/software/jira/docs/api/REST/7.1.2/
+ * https://ecosystem.atlassian.net/wiki/spaces/JRJC/overview
  * <p>
  * JIRA (R) Issue tracking project management software
  * (http://www.atlassian.com/software/jira)
@@ -147,7 +162,7 @@ public void add(final TimeSlot timeSlot) throws IssueTrackerException {
     // analyze the existing worklog status and duration
     final long duration;
     final Attribute statusAttribute = getIssueWorkLogDuration(timeSlot);
-    if (statusAttribute != null) {
+    if (statusAttribute != null && !version.equals(JIRA_VERSION_6)) {
       int lastDuration = Integer
           .parseInt(String.valueOf(statusAttribute.get()));
       if (timeSlot.getTime() <= lastDuration) {
@@ -157,8 +172,12 @@ public void add(final TimeSlot timeSlot) throws IssueTrackerException {
       }
 
       duration = timeSlot.getTime() - lastDuration;
+
+      LOG.info("Stop => timeSlot.getTime()=" + timeSlot.getTime() + " duration=" + duration + " lastDuration= " + lastDuration);
     } else {
       duration = timeSlot.getTime();
+
+      LOG.info("Stop => timeSlot.getTime()=" + timeSlot.getTime() + " duration=" + duration);
     }
 
     Runnable searchIssueTask = () -> {
@@ -179,8 +198,10 @@ public void add(final TimeSlot timeSlot) throws IssueTrackerException {
           addWorklog(timeSlot, key, issueId, statusAttribute,
               duration);
         } catch (IOException e) {
-          LOG.warning("Error occured while updating jira worklog:"
-              + e.getMessage());
+        	final String start = formatDate(timeSlot.getStartDate());
+
+          LOG.log(Level.WARNING, "Error occured while updating jira worklog for issue " + key +
+        		  " (start=" + start + " duration=" + duration + ")", e);
         }
       };
       executorService.execute(updateWorklogTask);
@@ -189,13 +210,27 @@ public void add(final TimeSlot timeSlot) throws IssueTrackerException {
   }
 
   private Attribute getIssueWorkLogDuration(final TimeSlot timeSlot) {
-    for (Attribute attribute : timeSlot.getAttributes()) {
-      if (attribute.getAttributeType().equals(issueWorklogStatusType)) {
-        return attribute;
-      }
-    }
+    return getAttribute(timeSlot, issueWorklogStatusType);
+  }
 
-    return null;
+  private Attribute getAttribute(final TimeSlot timeSlot, final AttributeType attrType) {
+	    for (Attribute attribute : timeSlot.getAttributes()) {
+	      if (attribute.getAttributeType().equals(attrType)) {
+	        return attribute;
+	      }
+	    }
+
+	    return null;
+	  }
+
+  private long getTimeSpentInSeconds(final TimeSlot timeslot)
+  {
+	  final Attribute attr = getIssueWorkLogDuration(timeslot);
+
+	  if (attr == null)
+		  return -1L;
+
+	  return Long.parseLong(String.valueOf(attr.get())) / 1000L;
   }
 
   @Override
@@ -366,11 +401,27 @@ public boolean isValidKey(String key) {
                           final String issueId, Attribute statusAttribute,
                           long duration)
       throws IOException {
-    URL url = new URL(getBaseJiraUrl() + getAddWorklogPath(issueId));
-    URLConnection connection = getUrlConnection(url);
+
+	  final StringBuilder sb = new StringBuilder();
+
+	  sb.append(getBaseJiraUrl()).append(getAddWorklogPath(issueId));
+
+	  String requestMethod = "POST";
+
+	  if (version.equals(JIRA_VERSION_6)) {
+	    final Attribute worklogId = getAttribute(timeSlot, IssueWorklogIdType.getInstance());
+
+	    if (worklogId != null) {
+	    	sb.append('/').append(worklogId.get());
+	    	requestMethod = "PUT";
+	    }
+	  }
+
+	final URL url = new URL(sb.toString());
+	final URLConnection connection = getUrlConnection(url);
     if (connection instanceof HttpURLConnection) {
       HttpURLConnection httpConnection = (HttpURLConnection) connection;
-      httpConnection.setRequestMethod("POST");
+      httpConnection.setRequestMethod(requestMethod);
       httpConnection.setDoInput(true);
       httpConnection.setDoOutput(true);
       httpConnection.setUseCaches(false);
@@ -378,16 +429,25 @@ public boolean isValidKey(String key) {
           getContentType());
 
       // sending data
-      OutputStreamWriter writer = new OutputStreamWriter(
-          httpConnection.getOutputStream());
-      try {
+      try (final OutputStreamWriter writer = new OutputStreamWriter(httpConnection.getOutputStream()))
+      {
 
         String jiraDuration = (duration / 1000 / 60) + "m";
+        LOG.finest("addWorkLog => jiraDuration=" + jiraDuration +
+        		" started=" + formatDate(timeSlot.getStartDate()) +
+        		" comment=" + timeSlot.getDescription() +
+        		" toString=" + timeSlot.toString()
+        		);
         if (version.equals(JIRA_VERSION_6)) {
-          writer.append("{").append(getPairSC("timeSpent", jiraDuration)).append(",")
-              .append(getPairSC("started", formatDate(timeSlot.getStartDate()))).append(",")
-              .append(getPairSC("comment", timeSlot.getDescription()))
-              .append("}");
+        	final JsonObject jsonObject = new JsonObject();
+
+        	jsonObject.addProperty("timeSpentSeconds", duration / 1000L);
+        	jsonObject.addProperty("started", formatDate(timeSlot.getStartDate()));
+        	jsonObject.addProperty("comment", timeSlot.getDescription());
+
+        	final String json = jsonObject.toString();
+
+        	writer.append(json);
         } else {
           writer.append(getAuthorizedParams()).append(getPair("id", issueId))
               .append(getPair("comment", URLEncoder.encode(timeSlot.getDescription(), "UTF-8")))
@@ -399,20 +459,34 @@ public boolean isValidKey(String key) {
               .append(getPair("newEstimate", ""))
               .append(getPair("commentLevel", ""));
         }
-      } finally {
-        writer.flush();
-        writer.close();
       }
-      BufferedReader br = new BufferedReader(
-          new InputStreamReader(connection.getInputStream()));
-      String line = br.readLine();
-      br.close();
-      LOG.finest("jira result: " + line);
+
+      if (version.equals(JIRA_VERSION_6))
+      {
+          try (final Reader reader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))
+          {
+              final JsonObject jsonObj = JsonParser.parseReader(reader).getAsJsonObject();
+              final String id = jsonObj.get("id").getAsString();
+
+              getOrCreate(timeSlot, IssueWorklogIdType.getInstance()).set(id);
+
+              LOG.finest("jira result: " + jsonObj.toString());
+          }
+      }
+      else
+      {
+          try (final BufferedReader br = new BufferedReader(
+                  new InputStreamReader(connection.getInputStream())))
+          {
+              final String line = br.readLine();
+
+              LOG.finest("jira result: " + line);
+          }
+      }
 
       if (statusAttribute == null) {
         statusAttribute = new Attribute(issueWorklogStatusType);
-        List<Attribute> list = new ArrayList<Attribute>(
-            timeSlot.getAttributes());
+        final List<Attribute> list = new ArrayList<Attribute>(timeSlot.getAttributes());
         list.add(statusAttribute);
         timeSlot.setAttributes(list);
       }
@@ -421,6 +495,26 @@ public boolean isValidKey(String key) {
 
       LOG.info("Updated jira worklog with key: " + key);
     }
+  }
+
+  private Attribute getOrCreate(final TimeSlot timeslot, final AttributeType attrType)
+  {
+	  final Collection<Attribute> attrs = timeslot.getAttributes();
+
+	  synchronized(attrs)
+	  {
+		  if (attrs != null) for (final Attribute attr : attrs)
+		  {
+			  if (attr.getAttributeType().equals(attrType))
+				  return attr;
+		  }
+
+		  final Attribute attr = new Attribute(attrType);
+
+		  attrs.add(attr);
+
+		  return attr;
+	  }
   }
 
   private String getAddWorklogPath(String issueId) {
@@ -486,10 +580,6 @@ public boolean isValidKey(String key) {
         .getString(Configuration.JIRA_LOGIN, "");
   }
 
-  private String getPairSC(String name, String value) {
-    return "\"" + name + "\"" + ":" + "\"" +value + "\"";
-  }
-
   private String getPair(String name, String value) {
     return "&" + name + "=" + value;
   }
@@ -521,6 +611,11 @@ public boolean isValidKey(String key) {
   }
 
   private void init() {
+	  fixFailed();
+
+	  if (Boolean.getBoolean("validate-failed"))
+		  validateFailed();
+
     // updates when timeslot changed
     this.timeSlotTracker.getLayoutManager()
         .addActionListener(new TimeSlotChangedListener() {
@@ -571,4 +666,264 @@ public boolean isValidKey(String key) {
         });
   }
 
+  private void fixFailed()
+  {
+	  final List<Task> jiraTasks = getAllJiraTasks();
+
+	  for (final Task jiraTask : jiraTasks)
+	  {
+		  final Collection<TimeSlot> timeslots = jiraTask.getTimeslots();
+
+		  if (timeslots != null) for (final TimeSlot timeslot : timeslots)
+		  {
+			  final long timeSpentInSeconds = getTimeSpentInSeconds(timeslot);
+
+			  if (timeSpentInSeconds < 0L)
+			  {
+				  try
+				  {
+					  add(timeslot);
+				  }
+				  catch (IssueTrackerException e)
+				  {
+					  LOG.log(Level.WARNING, "Problem rescheduling Jira update for " +
+							  getIssueKey(timeslot.getTask()), e);
+				  }
+			  }
+		  }
+	  }
+  }
+
+  private void validateFailed()
+  {
+	  if (!version.equals(JIRA_VERSION_6))
+		  return;
+
+	  final List<Task> jiraTasks = getAllJiraTasks();
+	  final Map<String, UnsavedWorkLog> unsaved = new HashMap<>();
+
+	  for (final Task jiraTask : jiraTasks)
+	  {
+		  final List<WorkLog> worklogs = getWorklogs(jiraTask);
+		  final List<TimeSlot> missingTimeSlots = getMissingTimeSlots(jiraTask, worklogs);
+
+		  if (!missingTimeSlots.isEmpty())
+		  {
+			  unsaved.put(getIssueKey(jiraTask), new UnsavedWorkLog(jiraTask, missingTimeSlots));
+		  }
+	  }
+
+	  LOG.warning(unsaved.size() + " issues are missing timeslots");
+  }
+
+  private List<Task> getAllJiraTasks()
+  {
+	  final List<Task> jiraTasks = new ArrayList<>();
+
+	  findAllJiraTasks(jiraTasks, timeSlotTracker.getDataSource().getRoot());
+
+	  return jiraTasks;
+  }
+
+  private void findAllJiraTasks(final List<Task> jiraTasks, final Task task)
+  {
+	  final String key = getIssueKey(task);
+
+	  if (key != null)
+	  {
+		  jiraTasks.add(task);
+	  }
+
+	  final Collection<Task> children = task.getChildren();
+
+	  if (children != null) for (final Task child : children)
+	  {
+		  findAllJiraTasks(jiraTasks, child);
+	  }
+  }
+
+	private List<WorkLog> getWorklogs(final Task jiraTask)
+	{
+		final List<WorkLog> rtrn = new ArrayList<>();
+		final String issueKey = getIssueKey(jiraTask);
+
+		try
+		{
+			final URL url = new URL(getBaseJiraUrl() + getAddWorklogPath(issueKey));
+			final HttpURLConnection httpConnection = (HttpURLConnection) getUrlConnection(url);
+
+			httpConnection.setRequestMethod("GET");
+			httpConnection.setDoInput(true);
+			httpConnection.setDoOutput(false);
+			httpConnection.setUseCaches(false);
+			httpConnection.setRequestProperty("Content-Type", "application/json");
+
+			try (final InputStream is = httpConnection.getInputStream();
+				 final JsonReader jr = new JsonReader(new InputStreamReader(is, StandardCharsets.UTF_8)))
+			{
+				jr.beginObject();
+
+				while (jr.hasNext() && JsonToken.END_OBJECT != jr.peek())
+				{
+					final String name = jr.nextName();
+
+					if ("worklogs".contentEquals(name))
+					{
+						jr.beginArray();
+
+						while (jr.hasNext() && JsonToken.END_ARRAY != jr.peek())
+						{
+							rtrn.add(parseWorkLog(jr));
+						}
+
+						jr.endArray();
+					}
+					else
+					{
+						jr.skipValue();
+					}
+				}
+
+				jr.endObject();
+			}
+		}
+		catch (final Exception e)
+		{
+			LOG.log(Level.WARNING, "Problem while retrieving work logs for Jira issue " + issueKey, e);
+		}
+
+		return rtrn;
+	}
+
+	private WorkLog parseWorkLog(final JsonReader jr)
+			throws IOException, ParseException
+	{
+		String id = null;
+		long timeSpentSeconds = -1L;
+		Date started = null;
+
+		jr.beginObject();
+
+		while (jr.hasNext())
+		{
+			final JsonToken token = jr.peek();
+
+			if (JsonToken.END_OBJECT == token)
+				break;
+
+			final String name = jr.nextName();
+
+			switch(name)
+			{
+			case "id":
+				id = jr.nextString();
+				break;
+			case "timeSpentSeconds":
+				timeSpentSeconds = jr.nextLong();
+				break;
+			case "started":
+				synchronized(TIMESTAMP)
+				{
+					started = TIMESTAMP.parse(jr.nextString());
+				}
+				break;
+			default:
+				jr.skipValue();
+				 break;
+			}
+		}
+
+		jr.endObject();
+
+		if (id == null || started == null || timeSpentSeconds < 0)
+			throw new IOException("WorkLog is missing information.");
+
+		return new WorkLog(id, started, timeSpentSeconds);
+	}
+
+  private List<TimeSlot> getMissingTimeSlots(final Task jiraTask, final List<WorkLog> worklogs)
+  {
+	  final Collection<TimeSlot> timeslots = jiraTask.getTimeslots();
+	  final List<TimeSlot> missingTimeslots = new ArrayList<>();
+
+	  if (timeslots != null) for (final TimeSlot timeslot : timeslots)
+	  {
+		  final long timeSpentInSeconds = getTimeSpentInSeconds(timeslot);
+
+		  if (timeSpentInSeconds < 0L)
+		  {
+			  missingTimeslots.add(timeslot);
+		  }
+		  else
+		  {
+			  final WorkLog worklog = findWorkLog(timeslot, worklogs);
+
+			  if (worklog == null)
+			  {
+				  missingTimeslots.add(timeslot);
+			  }
+		  }
+	  }
+
+	  return missingTimeslots;
+  }
+
+  private WorkLog findWorkLog(final TimeSlot timeslot, final List<WorkLog> worklogs)
+  {
+	  final Date start = timeslot.getStartDate();
+
+	  for (final WorkLog worklog : worklogs)
+	  {
+		  if (Math.abs(worklog.start.getTime() - start.getTime()) < 5000L)
+		  {
+			  final long timeSpentSeconds = getTimeSpentInSeconds(timeslot);
+
+			  if (timeSpentSeconds >= 0 && timeSpentSeconds != worklog.timeSpentSeconds)
+			  {
+				  final String dateStr = formatDate(worklog.start);
+				  final String cmp = timeSpentSeconds < worklog.timeSpentSeconds ? "much" : "little";
+
+				  LOG.warning("Work Log time spent does not match for " +
+						  getIssueKey(timeslot.getTask()) +
+						  " (" + timeSpentSeconds + " vs " + worklog.timeSpentSeconds +
+						  " at " + dateStr + " -- Jira has too " + cmp + ")");
+			  }
+
+			  return worklog;
+		  }
+	  }
+
+	  return null;
+  }
+
+  private static final class WorkLog
+  {
+	  private final String id;
+	  private final Date start;
+	  private final long timeSpentSeconds;
+
+	  private WorkLog(final String id, final Date start, final long duration)
+	  {
+		  this.id = id;
+		  this.start = start;
+		  this.timeSpentSeconds = duration;
+	  }
+  }
+
+  private static final class UnsavedWorkLog
+  {
+	  private final Task task;
+	  private final List<TimeSlot> timeSlots;
+
+	  UnsavedWorkLog(final Task task, final List<TimeSlot> unsavedWorkLogs)
+	  {
+		  this.task = task;
+		  this.timeSlots = unsavedWorkLogs;
+	  }
+
+	  List<TimeSlot> geTimeSlots()
+	  {
+		  return timeSlots;
+	  }
+  }
 }

--- a/resources/java/net/sf/timeslottracker/integrations/issuetracker/jira/JiraTracker.java
+++ b/resources/java/net/sf/timeslottracker/integrations/issuetracker/jira/JiraTracker.java
@@ -1,67 +1,19 @@
 package net.sf.timeslottracker.integrations.issuetracker.jira;
 
-import java.io.BufferedReader;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.io.Reader;
-import java.net.HttpURLConnection;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.text.DateFormat;
-import java.text.MessageFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.swing.JOptionPane;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-
-import org.apache.commons.codec.binary.Base64;
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
-
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
 
 import net.sf.timeslottracker.core.Action;
 import net.sf.timeslottracker.core.Configuration;
 import net.sf.timeslottracker.core.TimeSlotTracker;
-import net.sf.timeslottracker.data.Attribute;
-import net.sf.timeslottracker.data.AttributeType;
 import net.sf.timeslottracker.data.DataLoadedListener;
 import net.sf.timeslottracker.data.Task;
 import net.sf.timeslottracker.data.TimeSlot;
 import net.sf.timeslottracker.data.TimeSlotChangedListener;
 import net.sf.timeslottracker.integrations.issuetracker.Issue;
 import net.sf.timeslottracker.integrations.issuetracker.IssueHandler;
-import net.sf.timeslottracker.integrations.issuetracker.IssueKeyAttributeType;
 import net.sf.timeslottracker.integrations.issuetracker.IssueTracker;
 import net.sf.timeslottracker.integrations.issuetracker.IssueTrackerException;
-import net.sf.timeslottracker.integrations.issuetracker.IssueWorklogIdType;
-import net.sf.timeslottracker.integrations.issuetracker.IssueWorklogStatusType;
-import net.sf.timeslottracker.utils.StringUtils;
 
 /**
  * Implementation of Issue Tracker for Jira
@@ -73,857 +25,112 @@ import net.sf.timeslottracker.utils.StringUtils;
  */
 public class JiraTracker implements IssueTracker {
 
-  public static final String JIRA_VERSION_6 = "6";
-  public static final String JIRA_VERSION_310 = "3.10";
-  public static final String JIRA_VERSION_3 = "3";
-  private static final String JIRA_DEFAULT_VERSION = JIRA_VERSION_6;
-
-  private static final Logger LOG = Logger
-      .getLogger(JiraTracker.class.getName());
-  private static String decodeString(String s) {
-    Pattern p = Pattern.compile("&#([\\d]+);");
-    Matcher m = p.matcher(s);
-    StringBuffer sb = new StringBuffer();
-    while (m.find()) {
-      m.appendReplacement(sb,
-          new String(Character.toChars(Integer.parseInt(m.group(1)))));
-    }
-    m.appendTail(sb);
-    return sb.toString();
-  }
-
-  private static String prepareKey(String key) {
-    if (key == null) {
-      return null;
-    }
-
-    return key.trim().toUpperCase();
-  }
-
-  private final SAXParserFactory saxFactory;
-
-  private final ExecutorService executorService;
-
-  private final IssueKeyAttributeType issueKeyAttributeType;
-
-  private final IssueWorklogStatusType issueWorklogStatusType;
-
-  private final Pattern patternIssueId = Pattern
-      .compile("<key id=\"([0-9]+)\">([\\d,\\s\u0021-\u0451]+)<");
-
-  private final Pattern patternSummary = Pattern
-      .compile("<summary>([\\d,\\s\u0021-\u0451]+)<");
-
-  /**
-   * JIRA password per application runtime session
-   */
-  private String sessionPassword = StringUtils.EMPTY;
-
-  private final TimeSlotTracker timeSlotTracker;
-
-  private final String issueUrlTemplate;
-  private final String filterUrlTemplate;
-
-  private final String version;
-
-  public JiraTracker(final TimeSlotTracker timeSlotTracker) {
-    this.timeSlotTracker = timeSlotTracker;
-    this.executorService = Executors.newSingleThreadExecutor();
-
-    this.issueKeyAttributeType = IssueKeyAttributeType.getInstance();
-    this.issueWorklogStatusType = IssueWorklogStatusType.getInstance();
-
-    this.issueUrlTemplate = timeSlotTracker.getConfiguration().get(
-        Configuration.JIRA_ISSUE_URL_TEMPLATE,
-        "{0}/si/jira.issueviews:issue-xml/{1}/?{2}");
-
-    this.version = timeSlotTracker.getConfiguration()
-        .get(Configuration.JIRA_VERSION, JIRA_DEFAULT_VERSION);
-
-    this.filterUrlTemplate = timeSlotTracker.getConfiguration().get(
-        Configuration.JIRA_FILTER_URL_TEMPLATE,
-        "{0}/sr/jira.issueviews:searchrequest-xml/{1}/SearchRequest-{1}.xml?tempMax=1000&{2}");
-
-    this.timeSlotTracker.addActionListener((DataLoadedListener) action -> init());
-
-    this.saxFactory = SAXParserFactory.newInstance();
-  }
-
-  @Override
-public void add(final TimeSlot timeSlot) throws IssueTrackerException {
-    // getting issue key
-    final String key = getIssueKey(timeSlot.getTask());
-    if (key == null) {
-      return;
-    }
-
-    LOG.info("Updating jira worklog for issue with key " + key + " ...");
-
-    // analyze the existing worklog status and duration
-    final long duration;
-    final Attribute statusAttribute = getIssueWorkLogDuration(timeSlot);
-    if (statusAttribute != null && !version.equals(JIRA_VERSION_6)) {
-      int lastDuration = Integer
-          .parseInt(String.valueOf(statusAttribute.get()));
-      if (timeSlot.getTime() <= lastDuration) {
-        LOG.info("Skipped updating jira worklog for issue with key " + key
-            + ". Reason: current timeslot duration <= already saved in worklog");
-        return;
-      }
-
-      duration = timeSlot.getTime() - lastDuration;
-
-      LOG.info("Stop => timeSlot.getTime()=" + timeSlot.getTime() + " duration=" + duration + " lastDuration= " + lastDuration);
-    } else {
-      duration = timeSlot.getTime();
-
-      LOG.info("Stop => timeSlot.getTime()=" + timeSlot.getTime() + " duration=" + duration);
-    }
-
-    Runnable searchIssueTask = () -> {
-      Issue issue = null;
-      try {
-        issue = getIssue(key);
-      } catch (IssueTrackerException e2) {
-        LOG.info(e2.getMessage());
-      }
-      if (issue == null) {
-        LOG.info("Nothing updated. Not found issue with key " + key);
-        return;
-      }
-
-      final String issueId = issue.getId();
-      Runnable updateWorklogTask = () -> {
-        try {
-          addWorklog(timeSlot, key, issueId, statusAttribute,
-              duration);
-        } catch (IOException e) {
-        	final String start = formatDate(timeSlot.getStartDate());
-
-          LOG.log(Level.WARNING, "Error occured while updating jira worklog for issue " + key +
-        		  " (start=" + start + " duration=" + duration + ")", e);
-        }
-      };
-      executorService.execute(updateWorklogTask);
-    };
-    executorService.execute(searchIssueTask);
-  }
-
-  private Attribute getIssueWorkLogDuration(final TimeSlot timeSlot) {
-    return getAttribute(timeSlot, issueWorklogStatusType);
-  }
-
-  private Attribute getAttribute(final TimeSlot timeSlot, final AttributeType attrType) {
-	    for (Attribute attribute : timeSlot.getAttributes()) {
-	      if (attribute.getAttributeType().equals(attrType)) {
-	        return attribute;
-	      }
-	    }
-
-	    return null;
-	  }
-
-  private long getTimeSpentInSeconds(final TimeSlot timeslot)
-  {
-	  final Attribute attr = getIssueWorkLogDuration(timeslot);
-
-	  if (attr == null)
-		  return -1L;
-
-	  return Long.parseLong(String.valueOf(attr.get())) / 1000L;
-  }
-
-  @Override
-public Issue getIssue(String key) throws IssueTrackerException {
-    try {
-      key = prepareKey(key);
-      if (key == null) {
-        return null;
-      }
-
-      String urlString = MessageFormat.format(issueUrlTemplate,
-          getBaseJiraUrl(), key, getAuthorizedParams());
-      URL url = new URL(urlString);
-      URLConnection connection = getUrlConnection(url);
-      try {
-        BufferedReader br = new BufferedReader(
-            new InputStreamReader(connection.getInputStream()));
-        String line = br.readLine();
-        String id = null;
-        String summary = null;
-        while (line != null) {
-          line = decodeString(line);
-          Matcher matcherId = patternIssueId.matcher(line);
-          if (id == null && matcherId.find()) {
-            id = matcherId.group(1);
-            continue;
-          }
-
-          Matcher matcherSummary = patternSummary.matcher(line);
-          if (summary == null && matcherSummary.find()) {
-            summary = matcherSummary.group(1);
-            continue;
-          }
-
-          if (id != null && summary != null) {
-            return new JiraIssue(key, id, summary);
-          }
-
-          line = br.readLine();
-        }
-      } finally {
-        connection.getInputStream().close();
-      }
-      return null;
-    } catch (FileNotFoundException e) {
-      return null;
-    } catch (IOException e) {
-      throw new IssueTrackerException(e);
-    }
-  }
-
-  @Override
-  public URI getIssueUrl(Task task) throws IssueTrackerException {
-    String issueKey = getIssueKey(task);
-
-    if (issueKey == null) {
-      throw new IssueTrackerException("Given task \"" + task.getName()
-          + "\" is not issue task (i.e. does not has issue key attribute)");
-    }
-
-    String uriStr = getBaseJiraUrl() + "/browse/" + issueKey;
-    try {
-      return new URI(uriStr);
-    } catch (URISyntaxException e) {
-      throw new IssueTrackerException(
-          "Error occured while creating uri: " + uriStr);
-    }
-  }
-
-  @Override
-  public void getFilterIssues(final String filterId, final IssueHandler handler)
-      throws IssueTrackerException {
-      executorService.execute(() -> {
-        try {
-			String urlString;
-
-			try {
-				Long.parseLong(filterId);
-
-				urlString = MessageFormat.format(filterUrlTemplate,
-					getBaseJiraUrl(), filterId, getAuthorizedParams());
-			}
-			catch (final NumberFormatException e) {
-				// https://community.atlassian.com/t5/Jira-questions/Unable-to-fetch-XML-file-when-logged-out-from-JIRA-site/qaq-p/658398
-				urlString = getBaseJiraUrl() +
-					"/sr/jira.issueviews:searchrequest-xml/temp/SearchRequest.xml?jql=" + java.net.URLEncoder.encode(filterId, "UTF-8");
-			}
-
-          URL url = new URL(urlString);
-          URLConnection connection = getUrlConnection(url);
-          SAXParser saxParser = saxFactory.newSAXParser();
-
-          try (InputStream inputStream = connection.getInputStream()) {
-            saxParser.parse(inputStream, new DefaultHandler() {
-              StringBuilder stringBuilder = null;
-              JiraIssue jiraIssue;
-
-              @Override
-              public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-                if (handler.stopProcess()) {
-                  throw new SAXException("Cancel xml processing");
-                }
-
-                switch (qName) {
-                  case "summary":
-                    stringBuilder = new StringBuilder();
-                    break;
-                  case "item":
-                    jiraIssue = new JiraIssue();
-                    break;
-                  case "key":
-                    jiraIssue.setId(attributes.getValue("id"));
-                    stringBuilder = new StringBuilder();
-                    break;
-                  case "parent":
-                    jiraIssue.setSubTask(true);
-                    break;
-                }
-              }
-
-              @Override
-              public void characters(char[] ch, int start, int length) throws SAXException {
-                if (stringBuilder != null) {
-                  stringBuilder.append(new String(ch, start, length));
-                }
-              }
-
-              @Override
-              public void endElement(String uri, String localName, String qName) throws SAXException {
-                switch (qName) {
-                  case "item":
-                    try {
-                      handler.handle(jiraIssue);
-                    } catch (IssueTrackerException e) {
-                      LOG.throwing("", "", e);
-                    }
-                    jiraIssue = null;
-                    break;
-                  case "summary":
-                    jiraIssue.setSummary(stringBuilder.toString());
-                    break;
-                  case "key":
-                    jiraIssue.setKey(stringBuilder.toString());
-                    break;
-                }
-                stringBuilder = null;
-              }
-            });
-          }
-        } catch (Exception e) {
-          LOG.throwing("", "", e);
-        }
-      });
-  }
-
-  @Override
-public boolean isIssueTask(Task task) {
-    return task != null && getIssueKey(task) != null;
-  }
-
-  @Override
-public boolean isValidKey(String key) {
-    String preparedKey = prepareKey(key);
-    return preparedKey != null && preparedKey.matches("[a-z,A-Z0-9]+-[0-9]+");
-  }
-
-  private void addWorklog(final TimeSlot timeSlot, final String key,
-                          final String issueId, Attribute statusAttribute,
-                          long duration)
-      throws IOException {
-
-	  final StringBuilder sb = new StringBuilder();
-
-	  sb.append(getBaseJiraUrl()).append(getAddWorklogPath(issueId));
-
-	  String requestMethod = "POST";
-
-	  if (version.equals(JIRA_VERSION_6)) {
-	    final Attribute worklogId = getAttribute(timeSlot, IssueWorklogIdType.getInstance());
-
-	    if (worklogId != null) {
-	    	sb.append('/').append(worklogId.get());
-	    	requestMethod = "PUT";
-	    }
-	  }
-
-	final URL url = new URL(sb.toString());
-	final URLConnection connection = getUrlConnection(url);
-    if (connection instanceof HttpURLConnection) {
-      HttpURLConnection httpConnection = (HttpURLConnection) connection;
-      httpConnection.setRequestMethod(requestMethod);
-      httpConnection.setDoInput(true);
-      httpConnection.setDoOutput(true);
-      httpConnection.setUseCaches(false);
-      httpConnection.setRequestProperty("Content-Type",
-          getContentType());
-
-      // sending data
-      try (final OutputStreamWriter writer = new OutputStreamWriter(httpConnection.getOutputStream()))
-      {
-
-        String jiraDuration = (duration / 1000 / 60) + "m";
-        LOG.finest("addWorkLog => jiraDuration=" + jiraDuration +
-        		" started=" + formatDate(timeSlot.getStartDate()) +
-        		" comment=" + timeSlot.getDescription() +
-        		" toString=" + timeSlot.toString()
-        		);
-        if (version.equals(JIRA_VERSION_6)) {
-        	final JsonObject jsonObject = new JsonObject();
-
-        	jsonObject.addProperty("timeSpentSeconds", duration / 1000L);
-        	jsonObject.addProperty("started", formatDate(timeSlot.getStartDate()));
-        	jsonObject.addProperty("comment", timeSlot.getDescription());
-
-        	final String json = jsonObject.toString();
-
-        	writer.append(json);
-        } else {
-          writer.append(getAuthorizedParams()).append(getPair("id", issueId))
-              .append(getPair("comment", URLEncoder.encode(timeSlot.getDescription(), "UTF-8")))
-              .append(getPair("worklogId", ""))
-              .append(getPair("timeLogged", jiraDuration))
-              .append(getPair("startDate", URLEncoder.encode(new SimpleDateFormat("dd/MMM/yy KK:mm a")
-                      .format(timeSlot.getStartDate()), "UTF-8")))
-              .append(getPair("adjustEstimate", "auto"))
-              .append(getPair("newEstimate", ""))
-              .append(getPair("commentLevel", ""));
-        }
-      }
-
-      if (version.equals(JIRA_VERSION_6))
-      {
-          try (final Reader reader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8))
-          {
-              final JsonObject jsonObj = JsonParser.parseReader(reader).getAsJsonObject();
-              final String id = jsonObj.get("id").getAsString();
-
-              getOrCreate(timeSlot, IssueWorklogIdType.getInstance()).set(id);
-
-              LOG.finest("jira result: " + jsonObj.toString());
-          }
-      }
-      else
-      {
-          try (final BufferedReader br = new BufferedReader(
-                  new InputStreamReader(connection.getInputStream())))
-          {
-              final String line = br.readLine();
-
-              LOG.finest("jira result: " + line);
-          }
-      }
-
-      if (statusAttribute == null) {
-        statusAttribute = new Attribute(issueWorklogStatusType);
-        final List<Attribute> list = new ArrayList<Attribute>(timeSlot.getAttributes());
-        list.add(statusAttribute);
-        timeSlot.setAttributes(list);
-      }
-
-      statusAttribute.set(timeSlot.getTime());
-
-      LOG.info("Updated jira worklog with key: " + key);
-    }
-  }
-
-  private Attribute getOrCreate(final TimeSlot timeslot, final AttributeType attrType)
-  {
-	  final Collection<Attribute> attrs = timeslot.getAttributes();
-
-	  synchronized(attrs)
-	  {
-		  if (attrs != null) for (final Attribute attr : attrs)
-		  {
-			  if (attr.getAttributeType().equals(attrType))
-				  return attr;
-		  }
-
-		  final Attribute attr = new Attribute(attrType);
-
-		  attrs.add(attr);
-
-		  return attr;
-	  }
-  }
-
-  private String getAddWorklogPath(String issueId) {
-    String path;
-    if (version.equals(JIRA_VERSION_3)) {
-      path = "/secure/LogWork.jspa";
-    }
-    else if (version.equals(JIRA_VERSION_310)) {
-      path = "/secure/CreateWorklog.jspa";
-    }
-    else {
-      path = "/rest/api/2/issue/" + issueId + "/worklog";
-    }
-    return path;
-  }
-
-  private String getContentType() {
-    return version.equals(JIRA_VERSION_6) ? "application/json" : "application/x-www-form-urlencoded";
-  }
-
-  private String getAuthorizedParams() {
-	  if (version.equals(JIRA_VERSION_6)) {
-		return "auth_ignore";
-	  } else {
-		return "os_username=" + getLogin() + getPair("os_password", getPassword());
-	  }
-  }
-
-  private URLConnection getUrlConnection(URL url) throws IOException {
-	  LOG.finest("Accessing : " + url);
-    URLConnection connection = url.openConnection();
-    // preparing connection
-    if (version.equals(JIRA_VERSION_6)) {
-      String basicAuth = "Basic " + new String(new Base64()
-          .encode((getLogin() + ":" + getPassword()).getBytes()));
-      connection.setRequestProperty("Authorization", basicAuth);
-    }
-    return connection;
-  }
-
-  private String getBaseJiraUrl() {
-    String url = this.timeSlotTracker.getConfiguration()
-        .getString(Configuration.JIRA_URL, "");
-
-    // truncate symbol / if present
-    if (url.endsWith("/")) {
-      url = url.substring(0, url.length() - 1);
-    }
-    return url;
-  }
-
-  private String getIssueKey(Task task) {
-    for (Attribute attribute : task.getAttributes()) {
-      if (attribute.getAttributeType().equals(issueKeyAttributeType)) {
-        return String.valueOf(attribute.get());
-      }
-    }
-    return null;
-  }
-
-  private String getLogin() {
-    return this.timeSlotTracker.getConfiguration()
-        .getString(Configuration.JIRA_LOGIN, "");
-  }
-
-  private String getPair(String name, String value) {
-    return "&" + name + "=" + value;
-  }
-
-  private String getPassword() {
-    String password = this.timeSlotTracker.getConfiguration()
-        .getString(Configuration.JIRA_PASSWORD, null);
-    if (!StringUtils.isBlank(password)) {
-      return password;
-    }
-
-    if (StringUtils.isBlank(sessionPassword)) {
-      sessionPassword = JOptionPane
-          .showInputDialog(timeSlotTracker.getRootFrame(), timeSlotTracker
-              .getString("issueTracker.credentialsInputDialog.password"));
-    }
-
-    return sessionPassword;
-  }
-
-  private static final DateFormat TIMESTAMP = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-
-  private static String formatDate(final Date d)
-  {
-	  synchronized(TIMESTAMP)
-	  {
-		  return TIMESTAMP.format(d);
-	  }
-  }
-
-  private void init() {
-	  fixFailed();
-
-	  if (Boolean.getBoolean("validate-failed"))
-		  validateFailed();
-
-    // updates when timeslot changed
-    this.timeSlotTracker.getLayoutManager()
-        .addActionListener(new TimeSlotChangedListener() {
-          @Override
-		public void actionPerformed(Action action) {
-            Boolean enabled = timeSlotTracker.getConfiguration()
-                .getBoolean(Configuration.JIRA_ENABLED, false);
-
-            if (!enabled) {
-              return;
-            }
-
-            if (!action.getName().equalsIgnoreCase("TimeSlotChanged")) {
-              return;
-            }
-
-            // no active timeSlot
-            TimeSlot timeSlot = (TimeSlot) action.getParam();
-            if (timeSlot == null) {
-              return;
-            }
-
-            boolean isNullStart = timeSlot.getStartDate() == null;
-            boolean isNullStop = timeSlot.getStopDate() == null;
-
-            // paused timeSlot
-            if (isNullStart && isNullStop) {
-              return;
-            }
-
-            // started timeSlot
-            if (isNullStop) {
-              return;
-            }
-
-            // removed timeSlot
-            if (timeSlot.getTask() == null) {
-              return;
-            }
-
-            // stopped or edited task
-            try {
-              add(timeSlot);
-            } catch (IssueTrackerException e) {
-              LOG.warning(e.getMessage());
-            }
-          }
-        });
-  }
-
-  private void fixFailed()
-  {
-	  final List<Task> jiraTasks = getAllJiraTasks();
-
-	  for (final Task jiraTask : jiraTasks)
-	  {
-		  final Collection<TimeSlot> timeslots = jiraTask.getTimeslots();
-
-		  if (timeslots != null) for (final TimeSlot timeslot : timeslots)
-		  {
-			  final long timeSpentInSeconds = getTimeSpentInSeconds(timeslot);
-
-			  if (timeSpentInSeconds < 0L)
-			  {
-				  try
-				  {
-					  add(timeslot);
-				  }
-				  catch (IssueTrackerException e)
-				  {
-					  LOG.log(Level.WARNING, "Problem rescheduling Jira update for " +
-							  getIssueKey(timeslot.getTask()), e);
-				  }
-			  }
-		  }
-	  }
-  }
-
-  private void validateFailed()
-  {
-	  if (!version.equals(JIRA_VERSION_6))
-		  return;
-
-	  final List<Task> jiraTasks = getAllJiraTasks();
-	  final Map<String, UnsavedWorkLog> unsaved = new HashMap<>();
-
-	  for (final Task jiraTask : jiraTasks)
-	  {
-		  final List<WorkLog> worklogs = getWorklogs(jiraTask);
-		  final List<TimeSlot> missingTimeSlots = getMissingTimeSlots(jiraTask, worklogs);
-
-		  if (!missingTimeSlots.isEmpty())
-		  {
-			  unsaved.put(getIssueKey(jiraTask), new UnsavedWorkLog(jiraTask, missingTimeSlots));
-		  }
-	  }
-
-	  LOG.warning(unsaved.size() + " issues are missing timeslots");
-  }
-
-  private List<Task> getAllJiraTasks()
-  {
-	  final List<Task> jiraTasks = new ArrayList<>();
-
-	  findAllJiraTasks(jiraTasks, timeSlotTracker.getDataSource().getRoot());
-
-	  return jiraTasks;
-  }
-
-  private void findAllJiraTasks(final List<Task> jiraTasks, final Task task)
-  {
-	  final String key = getIssueKey(task);
-
-	  if (key != null)
-	  {
-		  jiraTasks.add(task);
-	  }
-
-	  final Collection<Task> children = task.getChildren();
-
-	  if (children != null) for (final Task child : children)
-	  {
-		  findAllJiraTasks(jiraTasks, child);
-	  }
-  }
-
-	private List<WorkLog> getWorklogs(final Task jiraTask)
-	{
-		final List<WorkLog> rtrn = new ArrayList<>();
-		final String issueKey = getIssueKey(jiraTask);
-
-		try
-		{
-			final URL url = new URL(getBaseJiraUrl() + getAddWorklogPath(issueKey));
-			final HttpURLConnection httpConnection = (HttpURLConnection) getUrlConnection(url);
-
-			httpConnection.setRequestMethod("GET");
-			httpConnection.setDoInput(true);
-			httpConnection.setDoOutput(false);
-			httpConnection.setUseCaches(false);
-			httpConnection.setRequestProperty("Content-Type", "application/json");
-
-			try (final InputStream is = httpConnection.getInputStream();
-				 final JsonReader jr = new JsonReader(new InputStreamReader(is, StandardCharsets.UTF_8)))
-			{
-				jr.beginObject();
-
-				while (jr.hasNext() && JsonToken.END_OBJECT != jr.peek())
-				{
-					final String name = jr.nextName();
-
-					if ("worklogs".contentEquals(name))
-					{
-						jr.beginArray();
-
-						while (jr.hasNext() && JsonToken.END_ARRAY != jr.peek())
-						{
-							rtrn.add(parseWorkLog(jr));
-						}
-
-						jr.endArray();
-					}
-					else
-					{
-						jr.skipValue();
-					}
-				}
-
-				jr.endObject();
-			}
-		}
-		catch (final Exception e)
-		{
-			LOG.log(Level.WARNING, "Problem while retrieving work logs for Jira issue " + issueKey, e);
-		}
-
-		return rtrn;
+	public static final String JIRA_VERSION_6 = "6";
+	public static final String JIRA_VERSION_310 = "3.10";
+	public static final String JIRA_VERSION_3 = "3";
+	private static final String JIRA_DEFAULT_VERSION = JIRA_VERSION_6;
+
+	private static final Logger LOG = Logger.getLogger(JiraTracker.class.getName());
+
+	private final TimeSlotTracker timeSlotTracker;
+	
+	private final JiraClient jiraClient;
+
+	public JiraTracker(final TimeSlotTracker timeSlotTracker) {
+		this.timeSlotTracker = timeSlotTracker;
+
+		final String version = timeSlotTracker.getConfiguration().get(Configuration.JIRA_VERSION, JIRA_DEFAULT_VERSION);
+		
+		if (version.equals(JIRA_VERSION_6))
+			jiraClient = new JiraClientV6(timeSlotTracker);
+		else
+			jiraClient = new JiraClientImpl(timeSlotTracker, version);
+
+		this.timeSlotTracker.addActionListener((DataLoadedListener) action -> init());
 	}
 
-	private WorkLog parseWorkLog(final JsonReader jr)
-			throws IOException, ParseException
-	{
-		String id = null;
-		long timeSpentSeconds = -1L;
-		Date started = null;
-
-		jr.beginObject();
-
-		while (jr.hasNext())
-		{
-			final JsonToken token = jr.peek();
-
-			if (JsonToken.END_OBJECT == token)
-				break;
-
-			final String name = jr.nextName();
-
-			switch(name)
-			{
-			case "id":
-				id = jr.nextString();
-				break;
-			case "timeSpentSeconds":
-				timeSpentSeconds = jr.nextLong();
-				break;
-			case "started":
-				synchronized(TIMESTAMP)
-				{
-					started = TIMESTAMP.parse(jr.nextString());
-				}
-				break;
-			default:
-				jr.skipValue();
-				 break;
-			}
-		}
-
-		jr.endObject();
-
-		if (id == null || started == null || timeSpentSeconds < 0)
-			throw new IOException("WorkLog is missing information.");
-
-		return new WorkLog(id, started, timeSpentSeconds);
+	@Override
+	public void add(final TimeSlot timeSlot) throws IssueTrackerException {
+		jiraClient.upsertTimeslot(timeSlot);
 	}
 
-  private List<TimeSlot> getMissingTimeSlots(final Task jiraTask, final List<WorkLog> worklogs)
-  {
-	  final Collection<TimeSlot> timeslots = jiraTask.getTimeslots();
-	  final List<TimeSlot> missingTimeslots = new ArrayList<>();
+	@Override
+	public Issue getIssue(final String key) throws IssueTrackerException {
+		return jiraClient.getIssue(key);
+	}
 
-	  if (timeslots != null) for (final TimeSlot timeslot : timeslots)
-	  {
-		  final long timeSpentInSeconds = getTimeSpentInSeconds(timeslot);
+	@Override
+	public URI getIssueUrl(final Task task) throws IssueTrackerException {
+		return jiraClient.getIssueUrl(task);
+	}
 
-		  if (timeSpentInSeconds < 0L)
-		  {
-			  missingTimeslots.add(timeslot);
-		  }
-		  else
-		  {
-			  final WorkLog worklog = findWorkLog(timeslot, worklogs);
+	@Override
+	public void getFilterIssues(final String filterId, final IssueHandler handler) throws IssueTrackerException {
+		jiraClient.getFilterIssues(filterId, handler);
+	}
 
-			  if (worklog == null)
-			  {
-				  missingTimeslots.add(timeslot);
-			  }
-		  }
-	  }
+	@Override
+	public boolean isIssueTask(final Task task) {
+		return jiraClient.getIssueKey(task) != null;
+	}
 
-	  return missingTimeslots;
-  }
+	@Override
+	public boolean isValidKey(final String key) {
+		final String preparedKey = JiraClient.prepareKey(key);
+		return preparedKey != null && preparedKey.matches("[a-z,A-Z0-9]+-[0-9]+");
+	}
 
-  private WorkLog findWorkLog(final TimeSlot timeslot, final List<WorkLog> worklogs)
-  {
-	  final Date start = timeslot.getStartDate();
+	private void init() {
+		jiraClient.fixFailed();
 
-	  for (final WorkLog worklog : worklogs)
-	  {
-		  if (Math.abs(worklog.start.getTime() - start.getTime()) < 5000L)
-		  {
-			  final long timeSpentSeconds = getTimeSpentInSeconds(timeslot);
+		if (Boolean.getBoolean("validate-failed"))
+			jiraClient.validateFailed();
 
-			  if (timeSpentSeconds >= 0 && timeSpentSeconds != worklog.timeSpentSeconds)
-			  {
-				  final String dateStr = formatDate(worklog.start);
-				  final String cmp = timeSpentSeconds < worklog.timeSpentSeconds ? "much" : "little";
+		// updates when timeslot changed
+		this.timeSlotTracker.getLayoutManager().addActionListener(new TimeSlotChangedListener() {
+			@Override
+			public void actionPerformed(Action action) {
+				Boolean enabled = timeSlotTracker.getConfiguration().getBoolean(Configuration.JIRA_ENABLED, false);
 
-				  LOG.warning("Work Log time spent does not match for " +
-						  getIssueKey(timeslot.getTask()) +
-						  " (" + timeSpentSeconds + " vs " + worklog.timeSpentSeconds +
-						  " at " + dateStr + " -- Jira has too " + cmp + ")");
-			  }
+				if (!enabled) {
+					return;
+				}
 
-			  return worklog;
-		  }
-	  }
+				if (!action.getName().equalsIgnoreCase("TimeSlotChanged")) {
+					return;
+				}
 
-	  return null;
-  }
+				// no active timeSlot
+				TimeSlot timeSlot = (TimeSlot) action.getParam();
+				if (timeSlot == null) {
+					return;
+				}
 
-  private static final class WorkLog
-  {
-	  private final String id;
-	  private final Date start;
-	  private final long timeSpentSeconds;
+				boolean isNullStart = timeSlot.getStartDate() == null;
+				boolean isNullStop = timeSlot.getStopDate() == null;
 
-	  private WorkLog(final String id, final Date start, final long duration)
-	  {
-		  this.id = id;
-		  this.start = start;
-		  this.timeSpentSeconds = duration;
-	  }
-  }
+				// paused timeSlot
+				if (isNullStart && isNullStop) {
+					return;
+				}
 
-  private static final class UnsavedWorkLog
-  {
-	  private final Task task;
-	  private final List<TimeSlot> timeSlots;
+				// started timeSlot
+				if (isNullStop) {
+					return;
+				}
 
-	  UnsavedWorkLog(final Task task, final List<TimeSlot> unsavedWorkLogs)
-	  {
-		  this.task = task;
-		  this.timeSlots = unsavedWorkLogs;
-	  }
+				// removed timeSlot
+				if (timeSlot.getTask() == null) {
+					return;
+				}
 
-	  List<TimeSlot> geTimeSlots()
-	  {
-		  return timeSlots;
-	  }
-  }
+				// stopped or edited task
+				try {
+					add(timeSlot);
+				} catch (IssueTrackerException e) {
+					LOG.warning(e.getMessage());
+				}
+			}
+		});
+	}
 }


### PR DESCRIPTION
Allow adding & editing Jira issue worklogs when timeslots are added or edited.

Refactor the code so that the old Jira versions use the XML REST APIs while newer Jira version (6+) go all JSON. The JSON APIs are more efficient and they allow passing the Jira issue key (as opposed to the id which would require an extra lookup).

Update pom.xml so that the slim JAR references its dependencies relative to its location (i.e. TimeSlotTracker can be run without the big shaded JAR).